### PR TITLE
Added support for excluding certain dependencies from being flagged

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ pubghost --intl
 ### Commands
 
 - `--deps`: Check for unused dependencies declared in `pubspec.yaml`.
+> See [Configuration and Conventions](#configuration-and-conventions) to ignore specific dependencies.
 - `--widgets`: Check for unused classes/widgets under your project `lib/` directory.
 - `--intl`: Check for `.arb` keys not referenced in your code. Generated l10n directories are excluded.
 
@@ -87,6 +88,13 @@ pubghost --intl
   - `AppLocalizations.of(context).myKey`
   - `AppLocalizations.current.myKey`
   - `context.l10n.myKey`
+- Supports the exclusion of specific dependencies by adding a `pubghost` section in `pubspec.yaml`:
+> ```yaml
+> pubghost:
+>   ignore_dependencies:
+>     - flutter_launcher_icons
+> ```
+
 
 ## Limitations
 
@@ -94,7 +102,6 @@ pubghost --intl
   - Dynamically constructed imports/usages
   - Reflection or code generation outside the excluded folders
   - Intl keys used through non-standard access patterns
-- For `--deps`, only direct `package:` imports are considered usage. Transitive or runtime-only usages aren’t detected.
 
 ## CI
 

--- a/lib/pubghost.dart
+++ b/lib/pubghost.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 
+const packageName = 'pubghost';
+
 /// Scans `pubspec.yaml` dependencies vs `lib/` imports to report unused packages.
 Future<void> checkUnusedDependencies() async {
   final projectDir = Directory.current;
@@ -21,6 +23,19 @@ Future<void> checkUnusedDependencies() async {
   if (deps.isEmpty) {
     print('No dependencies found in pubspec.yaml.');
     exit(0);
+  }
+
+  final ignoredDeps = yaml[packageName]?['ignore_dependencies'];
+
+  // Remove any ignored dependencies as defined in the users `pubspec.yaml`
+  if (ignoredDeps is YamlList) {
+    for (final ignored in ignoredDeps) {
+      if (ignored is String) {
+        deps.remove(ignored);
+      }
+    }
+    // Remove our package by default
+    deps.remove(packageName);
   }
 
   final dartFiles = projectDir


### PR DESCRIPTION
## Description

First of all, awesome package and the reason I'm making this PR is because I want to apply this to some repositories ASAP. 

I have added the ability to define dependencies you want to ignore through the pubspec. Additionally I remove the `pubghost` package by default. This hopefully opens the door to full CI integration where any unused anything fails the pipeline.

## Demo

```
dart run pubghost --deps
Building package executable...
Built pubghost:pubghost.
⚠️  Unused packages (2):
 - bloc_test
 - very_good_analysis

```
> Note that I still have some unused dependencies for demonstration purposes, while also exposing myself for not testing my cubits 😅 